### PR TITLE
Fix typo constants and logging

### DIFF
--- a/src/main/java/com/Soo_Shinsa/global/exception/ErrorCode.java
+++ b/src/main/java/com/Soo_Shinsa/global/exception/ErrorCode.java
@@ -43,10 +43,10 @@ public enum ErrorCode {
     //권한이 없는 사용자가 수정, 삭제를 하려고 할 때
     NO_AUTHOR_CHANGE("수정, 삭제는 작성자만 할 수 있습니다.", HttpStatus.UNAUTHORIZED),
     NO_AUTHOR_READ_ONLY("읽기 전용 권한은 수정, 삭제를 할 수 없습니다.", HttpStatus.UNAUTHORIZED),
-    FAIl_IMAGE_DELETE("로컬 파일 삭제에 실패했습니다.", HttpStatus.BAD_REQUEST),
+    FAIL_IMAGE_DELETE("로컬 파일 삭제에 실패했습니다.", HttpStatus.BAD_REQUEST),
     MAX_10MB_SIZE("파일 크기가 10MB를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST),
     NO_EXTENSION("확장자가 없는 파일은 업로드할 수 없습니다.", HttpStatus.BAD_REQUEST),
-    NO_AUTHORITY("권헌이 없습니다.", HttpStatus.UNAUTHORIZED),
+    NO_AUTHORITY("권한이 없습니다.", HttpStatus.UNAUTHORIZED),
     NO_CONNECT("수정 또는 삭제할 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
     SELECT_COLOR_OR_SIZE("색상과 사이즈 중 하나는 필수입니다.",HttpStatus.BAD_REQUEST),
     FAIL_UPLOAD_FILE("이미지 업로드 중 오류가 발생했습니다.",HttpStatus.BAD_REQUEST),
@@ -74,7 +74,7 @@ public enum ErrorCode {
     ALREADY_CANCELED("이미 취소된 상품입니다", HttpStatus.BAD_REQUEST),
     INVALID_PAYMENT_AMOUNT("결제금액이 맞지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_PRODUCT_OPTION("옳지 않은 옵션 입니다.", HttpStatus.BAD_REQUEST),
-    LOCK_FAILED("락 획득 실패", HttpStatus.BAD_REQUEST),;
+    LOCK_FAILED("락 획득 실패", HttpStatus.BAD_REQUEST);
 
 
     private final String message;

--- a/src/main/java/com/Soo_Shinsa/global/utils/S3Uploader.java
+++ b/src/main/java/com/Soo_Shinsa/global/utils/S3Uploader.java
@@ -19,7 +19,7 @@ import java.net.URLDecoder;
 import java.util.Objects;
 import java.util.UUID;
 
-import static com.Soo_Shinsa.global.exception.ErrorCode.FAIl_IMAGE_DELETE;
+import static com.Soo_Shinsa.global.exception.ErrorCode.FAIL_IMAGE_DELETE;
 import static com.Soo_Shinsa.global.exception.ErrorCode.MAX_10MB_SIZE;
 
 @Slf4j
@@ -106,10 +106,10 @@ public class S3Uploader {
      */
     private void removeNewFile(File uploadFile) {
         if (!uploadFile.delete()) {
-            log.info("로컬 파일이 삭제되었습니다.");
-            throw new InvalidInputException(FAIl_IMAGE_DELETE);
+            log.error("로컬 파일이 삭제되지 않았습니다.");
+            throw new InvalidInputException(FAIL_IMAGE_DELETE);
         }
-        log.error("로컬 파일이 삭제되지 않았습니다.");
+        log.info("로컬 파일이 삭제되었습니다.");
     }
 
     private String putS3(File uploadFile, String fileName) {


### PR DESCRIPTION
## Summary
- correct typo in `FAIL_IMAGE_DELETE` enum and fix Korean message for `NO_AUTHORITY`
- fix S3Uploader logging when deleting temporary files

## Testing
- `./gradlew test --no-daemon` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847bbac83d883328107b00c9e47c684